### PR TITLE
Improve performance of graph algorithms

### DIFF
--- a/DistanceCalculation/Main.cs
+++ b/DistanceCalculation/Main.cs
@@ -16,10 +16,11 @@ namespace DistanceCalculation
 		public static void Log(string msg) => ModEntry.Logger.Log(msg);
 		public static void Warning(string msg) => ModEntry.Logger.Warning(msg);
 		public static void Error(string msg) => ModEntry.Logger.Error(msg);
+
 		public static void Error(string msg, Exception ex)
 		{
-			ModEntry.Logger.LogException(ex);
 			ModEntry.Logger.Error(msg);
+			ModEntry.Logger.LogException(ex);
 		}
 
 		private static Harmony? _harmony;


### PR DESCRIPTION
- Fix initialization checks in `TryBuildRailGraph`
- Use multi-target Dijkstra algorithm reducing redundant work
- Cache nearest graph node per station to avoid recomputing every time
- Some code cleanup

This fixes #3 for now; all in all, the graph initialization went from roughly 650 ms down to 150 ms.